### PR TITLE
Add option to use libcpuid instead of cpuid.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@
 $ sudo ./zenstates.py --no-gui [args...]
 ```
 
-    usage: zenstates.py [-h] [--no-gui] [-l] [-p {0,1,2,3,4,5,6,7}] [--enable] [--disable] [-f FID] [-d DID] [-v VID] 
-    [--smu-test-message]
+    usage: zenstates.py [-h] [-l] [--no-gui] [--libcpuid] [-p {0,1,2,3,4,5,6,7}] [--enable] [--disable] [-f FID] [-d DID] [-v VID]
+                    [--c6-enable] [--c6-disable] [--smu-test-message] [--oc-frequency OC_FREQUENCY] [--oc-vid OC_VID] [--ppt PPT]
+                    [--tdc TDC] [--edc EDC]
 
-    Sets parameters of Ryzen processors
-
-    required arguments:
-      --no-gui              Run in CLI without GUI
+    Dynamically edit AMD Ryzen processor parameters
 
     optional arguments:
-      -h, --help            Show this help message and exit
+      -h, --help            show this help message and exit
       -l, --list            List all P-States
+      --no-gui              Run in CLI without GUI
+      --libcpuid            Use libcpuid instead of cpuid.py
       -p {0,1,2,3,4,5,6,7}, --pstate {0,1,2,3,4,5,6,7}
                             P-State to set
       --enable              Enable P-State
@@ -41,12 +41,14 @@ $ sudo ./zenstates.py --no-gui [args...]
       -v VID, --vid VID     VID to set (in hex)
       --c6-enable           Enable C-State C6
       --c6-disable          Disable C-State C6
-      --smu-test-message    Send test message to the SMU (response 1 means 'success')
-      --oc-frequency        Set Overclock frequency (in MHz)
-      --oc-vid              Set Overclock VID (in hex)
-      --ppt                 Set PPT limit (in W)
-      --tdc                 Set TDC limit (in A)
-      --edc                 Set EDC limit (in A)
+      --smu-test-message    Send test message to the SMU (response 1 means "success")
+      --oc-frequency OC_FREQUENCY
+                            Set overclock frequency (in MHz)
+      --oc-vid OC_VID       Set overclock VID
+      --ppt PPT             Set PPT limit (in W)
+      --tdc TDC             Set TDC limit (in A)
+      --edc EDC             Set EDC limit (in A)
+
 
 ## GUI
   ![Screenshot](ZenStates%20for%20Linux%20v1.0_006.png?raw=true "ZenStates for Linux screenshot")


### PR DESCRIPTION
On some distros (Fedora, probably CentOS/RHEL too) the ability to set heap space executable is disabled by the default SELinux policy as a system hardening measure. This prevents `cpuid.py` from working since it tries to execute the CPUID instruction from heap space.

```
$ ./zenstates.py --no-gui -l
CPUs: 1
Traceback (most recent call last):
  File "/work/ZenStates-Linux/./zenstates.py", line 327, in <module>
    _cpuid = getCpuid()
  File "/work/ZenStates-Linux/./zenstates.py", line 190, in getCpuid
    eax, ebx, ecx, edx = getCpuidRegs(0x00000001)
  File "/work/ZenStates-Linux/./zenstates.py", line 185, in getCpuidRegs
    regs = cpuid.CPUID()(eax)
  File "/work/ZenStates-Linux/cpuid.py", line 116, in __init__
    raise OSError("Failed to set RWX")
OSError: Failed to set RWX
```

This PR implements the `--libcpuid` option to use the [native library](https://github.com/anrieff/libcpuid) via `ctypes` instead of `cpuid.py` to retrieve the same information.