### PR TITLE
PBO_SCALAR variable is undeclared in getOcMode

### DIFF
--- a/zenstates.py
+++ b/zenstates.py
@@ -27,6 +27,7 @@ SMU_CMD_OC_ENABLE =         0
 SMU_CMD_OC_DISABLE =        0
 SMU_CMD_OC_FREQ_ALL_CORES = 0
 SMU_CMD_OC_VID =            0
+SMU_CMD_GET_PBO_SCALAR =    0
 
 isOcFreqSupported = False
 cpu_sockets = int(os.popen('cat /proc/cpuinfo | grep "physical id" | sort -u | wc -l').read())


### PR DESCRIPTION
This is running on a desktop system with a Ryzen 1600.

The `if` from line 290 does not seem to set this variable, so when
running with the GUI and calling the getOcMode() function, the variable
is still undeclared.

NOTE: I do not know what the correct value should be to initialize the
PBO_SCALAR variable - I am using 0 because everything else there is
using 0.